### PR TITLE
Replace Loop with Array.join() in the Grammar Source

### DIFF
--- a/src/grammar.js
+++ b/src/grammar.js
@@ -113,10 +113,5 @@
     "string_char_single = [A-Za-z0-9., \"]"
   ];
 
-  var peg = "";
-  for (var i = 0; i < grammarArr.length; i++) {
-    peg += grammarArr[i] + "\n";
-  }
-
-  exports.Grammar.peg = peg;
+  exports.Grammar.peg = grammarArr.join('\n');
 })(typeof exports === 'undefined' ? this.Isla : exports);


### PR DESCRIPTION
Just replaced a loop, shortened it down by a few lines, just to make it more readable